### PR TITLE
[#87] Update CPDLC DCL format and add CLD header config

### DIFF
--- a/OKAC/Plugins/TopSky - Light/TopSkyCPDLC.txt
+++ b/OKAC/Plugins/TopSky - Light/TopSkyCPDLC.txt
@@ -1,5 +1,5 @@
 [DCL]
-DCL:OKKK:SID:CLRD TO <ades> OFF <drwy> VIA <sid> INIT CLB <cfl> SQUAWK <assr> NEXT FREQ <freq_own> <rmk>
+DCL:OKKK:SID:<callsign> CLRD TO <ades> OFF <drwy> VIA <sid><cr/lf>SQUAWK <assr> <atis<cr/lf>EOBT <eobt><cr/lf>ALT <cfl><cr/lf><rmk>
 
 [FREETEXT]
 FREETEXT:UNICOM:SERVICE TERMINATED. MONITOR 122.800

--- a/OKAC/Plugins/TopSky - Light/TopSkySettings.txt
+++ b/OKAC/Plugins/TopSky - Light/TopSkySettings.txt
@@ -99,6 +99,8 @@ CPDLC_ASP=1
 CPDLC_AutoAcceptLogon=0
 Window_CPDLC_Current=1,1000,0
 
+CPDLC_CLD_Header=CDA <hour><min> <year2><month2><day> <adep> PDC <number><cr/lf>
+
 CPDLC_PDC_Auto=1
 CPDLC_PDC_PlaySound=1
 

--- a/OKAC/Plugins/TopSky Aerodrome/TopSkyCPDLC.txt
+++ b/OKAC/Plugins/TopSky Aerodrome/TopSkyCPDLC.txt
@@ -1,5 +1,5 @@
 [DCL]
-DCL:OKKK:SID:CLRD TO <ades> OFF <drwy> VIA <sid> INIT CLB <cfl> SQUAWK <assr> NEXT FREQ <freq_own> <rmk>
+DCL:OKKK:SID:<callsign> CLRD TO <ades> OFF <drwy> VIA <sid><cr/lf>SQUAWK <assr> <atis<cr/lf>EOBT <eobt><cr/lf>ALT <cfl><cr/lf><rmk>
 
 [FREETEXT]
 

--- a/OKAC/Plugins/TopSky Aerodrome/TopSkySettings.txt
+++ b/OKAC/Plugins/TopSky Aerodrome/TopSkySettings.txt
@@ -98,6 +98,8 @@ CPDLC_ASP=1
 CPDLC_AutoAcceptLogon=0
 Window_CPDLC_Current=1,1000,0
 
+CPDLC_CLD_Header=CDA <hour><min> <year2><month2><day> <adep> PDC <number><cr/lf>
+
 CPDLC_PDC_Auto=1
 CPDLC_PDC_PlaySound=1
 

--- a/OKAC/Plugins/TopSky TMA/TopSkyCPDLC.txt
+++ b/OKAC/Plugins/TopSky TMA/TopSkyCPDLC.txt
@@ -1,5 +1,5 @@
 [DCL]
-DCL:OKKK:SID:CLRD TO <ades> OFF <drwy> VIA <sid> INIT CLB <cfl> SQUAWK <assr> NEXT FREQ <freq_own> <rmk>
+DCL:OKKK:SID:<callsign> CLRD TO <ades> OFF <drwy> VIA <sid><cr/lf>SQUAWK <assr> <atis<cr/lf>EOBT <eobt><cr/lf>ALT <cfl><cr/lf><rmk>
 
 [FREETEXT]
 

--- a/OKAC/Plugins/TopSky TMA/TopSkySettings.txt
+++ b/OKAC/Plugins/TopSky TMA/TopSkySettings.txt
@@ -99,6 +99,8 @@ CPDLC_ASP=1
 CPDLC_AutoAcceptLogon=0
 Window_CPDLC_Current=1,1000,0
 
+CPDLC_CLD_Header=CDA <hour><min> <year2><month2><day> <adep> PDC <number><cr/lf>
+
 CPDLC_PDC_Auto=1
 CPDLC_PDC_PlaySound=1
 

--- a/OKAC/Plugins/TopSky/TopSkyCPDLC.txt
+++ b/OKAC/Plugins/TopSky/TopSkyCPDLC.txt
@@ -1,5 +1,5 @@
 [DCL]
-DCL:OKKK:SID:CLRD TO <ades> OFF <drwy> VIA <sid> INIT CLB <cfl> SQUAWK <assr> NEXT FREQ <freq_own> <rmk>
+DCL:OKKK:SID:<callsign> CLRD TO <ades> OFF <drwy> VIA <sid><cr/lf>SQUAWK <assr> <atis<cr/lf>EOBT <eobt><cr/lf>ALT <cfl><cr/lf><rmk>
 
 [FREETEXT]
 FREETEXT:UNICOM:SERVICE TERMINATED. MONITOR 122.800

--- a/OKAC/Plugins/TopSky/TopSkySettings.txt
+++ b/OKAC/Plugins/TopSky/TopSkySettings.txt
@@ -99,6 +99,8 @@ CPDLC_ASP=1
 CPDLC_AutoAcceptLogon=0
 Window_CPDLC_Current=1,1000,0
 
+CPDLC_CLD_Header=CDA <hour><min> <year2><month2><day> <adep> PDC <number><cr/lf>
+
 CPDLC_PDC_Auto=1
 CPDLC_PDC_PlaySound=1
 


### PR DESCRIPTION
Update CPDLC clearance delivery messages across all TopSky profile variants:
- Modified DCL format to include callsign and EOBT with line breaks
- Added CPDLC_CLD_Header configuration for CDA clearance delivery format
- Applied to TopSky, TopSky Light, TopSky Aerodrome, and TopSky TMA profiles

Fixes #87 