### PR TITLE
[#62] Update badge label to vSID

### DIFF
--- a/.github/badges/vSID.json
+++ b/.github/badges/vSID.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "label": "vFPC",
+  "label": "vSID",
   "message": "0.14.1",
   "color": "blue"
 }


### PR DESCRIPTION
Correct the label in .github/badges/vSID.json from "vFPC" to "vSID" so the badge matches the file/project name. No other fields changed (schemaVersion and message remain the same).

Fixes #62